### PR TITLE
RD-258 (fix) : Working diag with kia soul ev turned off

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_kiasoulev/src/vehicle_kiasoulev.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_kiasoulev/src/vehicle_kiasoulev.cpp
@@ -205,13 +205,13 @@ static const char *TAG = "v-kiasoulev";
 // Pollstate 2 - car is charging
 static const OvmsPoller::poll_pid_t vehicle_kiasoulev_polls[] =
   {
-    { 0x7e2, 0x7ea, VEHICLE_POLL_TYPE_OBDIISESSION, 0x81, 		{       0,    2,   0 }, 0, ISOTP_STD }, 	// DIAG
-    { 0x7e2, 0x7ea, VEHICLE_POLL_TYPE_OBDII_1A,     0x90, 		{       0,   30,   0 }, 0, ISOTP_STD }, 	// VIN
-    { 0x7e4, 0x7ec, VEHICLE_POLL_TYPE_OBDIIGROUP,  	0x01, 		{       0,   10,  10 }, 0, ISOTP_STD }, 	// BMC Diag page 01 *
-    { 0x7e4, 0x7ec, VEHICLE_POLL_TYPE_OBDIIGROUP,  	0x02, 		{       0,   10,  10 }, 0, ISOTP_STD }, 	// BMC Diag page 02
-    { 0x7e4, 0x7ec, VEHICLE_POLL_TYPE_OBDIIGROUP,  	0x03, 		{       0,   10,  10 }, 0, ISOTP_STD }, 	// BMC Diag page 03
-    { 0x7e4, 0x7ec, VEHICLE_POLL_TYPE_OBDIIGROUP,  	0x04, 		{       0,   10,  10 }, 0, ISOTP_STD }, 	// BMC Diag page 04
-    { 0x7e4, 0x7ec, VEHICLE_POLL_TYPE_OBDIIGROUP,  	0x05, 		{       0,   10,  10 }, 0, ISOTP_STD },	    // BMC Diag page 05 *
+    { 0x7e2, 0x7ea, VEHICLE_POLL_TYPE_OBDIISESSION, 0x81, 		{       0,    2,   2 }, 0, ISOTP_STD }, 	// DIAG
+    { 0x7e2, 0x7ea, VEHICLE_POLL_TYPE_OBDII_1A,     0x90, 		{       0,   30,   30 }, 0, ISOTP_STD }, 	// VIN
+    { 0x7e4, 0x7ec, VEHICLE_POLL_TYPE_OBDIIGROUP,  	0x01, 		{       10,   10,  10 }, 0, ISOTP_STD }, 	// BMC Diag page 01 *
+    { 0x7e4, 0x7ec, VEHICLE_POLL_TYPE_OBDIIGROUP,  	0x02, 		{       10,   10,  10 }, 0, ISOTP_STD }, 	// BMC Diag page 02
+    { 0x7e4, 0x7ec, VEHICLE_POLL_TYPE_OBDIIGROUP,  	0x03, 		{       10,   10,  10 }, 0, ISOTP_STD }, 	// BMC Diag page 03
+    { 0x7e4, 0x7ec, VEHICLE_POLL_TYPE_OBDIIGROUP,  	0x04, 		{       10,   10,  10 }, 0, ISOTP_STD }, 	// BMC Diag page 04
+    { 0x7e4, 0x7ec, VEHICLE_POLL_TYPE_OBDIIGROUP,  	0x05, 		{       10,   10,  10 }, 0, ISOTP_STD },	    // BMC Diag page 05 *
     { 0x794, 0x79c, VEHICLE_POLL_TYPE_OBDIIGROUP,  	0x02, 		{       0,   60,  10 }, 0, ISOTP_STD }, 	// OBC - On board charger
     { 0x7e2, 0x7ea, VEHICLE_POLL_TYPE_OBDIIGROUP,  	0x00, 		{       0,   10,  10 }, 0, ISOTP_STD }, 	// VMCU Shift-stick
     { 0x7e2, 0x7ea, VEHICLE_POLL_TYPE_OBDIIGROUP,  	0x02, 		{       0,   10,  30 }, 0, ISOTP_STD }, 	// VMCU Motor temp++


### PR DESCRIPTION
### Related Ticket :
[RD258 - Diag not working on Kia Soul EV when in sleep mode](https://www.notion.so/Probl-me-de-mise-de-en-veille-de-la-KIA-Soul-EV-e96515d653224f05a8a74209ded1b9e9)

### Issue Fixed :
Previously, when the car was charging while locked, the OVMS didn't recognize it as charging but rather as turned off. This caused the cell voltages not to update, which prevented the diagnostic script from working properly.

### Notion Documentation Updated :
- No : client tutorials still aligned.

### Test Results :
- Diagnostics working on KNAJX81EFG7014069, all results are available on the DDR web client.