### PR TITLE
rd-391 : Tesla Model S battery current metric

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_teslamodels/src/vehicle_teslamodels.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_teslamodels/src/vehicle_teslamodels.cpp
@@ -125,11 +125,18 @@ void OvmsVehicleTeslaModelS::IncomingFrameCan1(CAN_frame_t* p_frame)
     {
     case 0x102: // BMS current and voltage
       {
-      // Don't update battery voltage too quickly (as it jumps around like crazy)
-      if (StandardMetrics.ms_v_bat_voltage->Age() > 10)
-        StandardMetrics.ms_v_bat_voltage->SetValue(((float)((int)d[1]<<8)+d[0])/100);
-      StandardMetrics.ms_v_bat_temp->SetValue((float)((((int)d[7]&0x07)<<8)+d[6])/10);
-      break;
+        // Don't update battery voltage too quickly (as it jumps around like crazy)
+        if (StandardMetrics.ms_v_bat_voltage->Age() > 10) {
+          StandardMetrics.ms_v_bat_voltage->SetValue(((float)((int)d[1]<<8)+d[0])/100);
+          StandardMetrics.ms_v_bat_temp->SetValue((float)((((int)d[7]&0x07)<<8)+d[6])/10);
+        }
+
+        //BMS battery current
+        if (StandardMetrics.ms_v_bat_current->Age() > 3) {
+          StandardMetrics.ms_v_bat_current->SetValue((float)((int16_t) ((uint8_t)d[3] << 8 | (uint8_t)d[2])) * 0.1f);
+        }
+
+        break;
       }
     case 0x116: // Gear selector
       {


### PR DESCRIPTION
# **Ticket:** [RD391 - Battery current metric for Tesla Model S](https://www.notion.so/Ajout-de-la-mesure-du-courant-15afed1f02e1803aa243e2a860638b9d)

## **Summary:**  
The main battery output current is now measured using CAN frame 0x102.

## **Key Changes:**  
- The ovms's metric `v.b.current` updated every 3s.